### PR TITLE
Add a very-verbose input

### DIFF
--- a/src/etos_client/__main__.py
+++ b/src/etos_client/__main__.py
@@ -137,6 +137,15 @@ def parse_args(args):
         "-v",
         "--verbose",
         dest="loglevel",
+        help="set loglevel to INFO",
+        action="store_const",
+        default=logging.WARNING,
+        const=logging.INFO,
+    )
+    parser.add_argument(
+        "-vv",
+        "--very-verbose",
+        dest="loglevel",
         help="set loglevel to DEBUG",
         action="store_const",
         default=logging.WARNING,


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Make it possible to only show 'INFO' messages when running with --no-tty.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Could just make the --verbose flag set INFO instead of DEBUG or default to INFO instead of WARNING.

### Benefits
<!-- What benefits will be realized by the change? -->
More configuration on the amount of output.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Another input parameter

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
