### PR TITLE
Add the ability to provide identity as a UUID

### DIFF
--- a/src/etos_client/__main__.py
+++ b/src/etos_client/__main__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -25,9 +25,7 @@ import json
 
 import requests
 from halo import Halo
-from packageurl import PackageURL
 from etos_lib.etos import ETOS
-from etos_lib.lib.debug import Debug
 
 from etos_client import __version__
 from etos_client.client import ETOSClient
@@ -70,14 +68,14 @@ def parse_args(args):
     parser.add_argument(
         "-i",
         "--identity",
-        help="Artifact created identity purl to execute test suite on.",
-        **environ_or_required("IDENTITY")
+        help="Artifact created identity purl or ID to execute test suite on.",
+        **environ_or_required("IDENTITY"),
     )
     parser.add_argument(
         "-s",
         "--test-suite",
         help="Test suite execute. Either URL or name.",
-        **environ_or_required("TEST_SUITE")
+        **environ_or_required("TEST_SUITE"),
     )
 
     parser.add_argument(
@@ -284,11 +282,10 @@ def main(args):
 
     setup_logging(args.loglevel)
     info = generate_spinner(args.no_tty)
-    identity = PackageURL.from_string(args.identity)
 
     for key, value in args._get_kwargs():  # pylint:disable=protected-access
         etos.config.set(key, value)
-    etos.config.set("identity", identity)
+    etos.config.set("identity", args.identity)
     etos.config.set("dataset", json.loads(args.dataset))
 
     with info(text="Checking connectivity to ETOS", spinner="dots") as spinner:
@@ -312,7 +309,11 @@ def main(args):
             # Unix  : 0 == Success, 1 == Fail
             # Python: 1 == True   , 0 == False
             sys.exit(not success)
+
         spinner.info("Suite ID: {}".format(etos_client.test_suite_id))
+        spinner.info("Artifact ID: {}".format(etos_client.artifact_id))
+        spinner.info("Purl: {}".format(etos_client.artifact_identity))
+
         etos.config.set("suite_id", etos_client.test_suite_id)
         os.environ["ETOS_GRAPHQL_SERVER"] = etos_client.event_repository
         spinner.info("Event repository: '{}'".format(etos.debug.graphql_server))

--- a/src/etos_client/__main__.py
+++ b/src/etos_client/__main__.py
@@ -285,7 +285,8 @@ def main(args):
 
     for key, value in args._get_kwargs():  # pylint:disable=protected-access
         etos.config.set(key, value)
-    etos.config.set("identity", args.identity)
+
+    etos.config.set("artifact_identifier", args.identity)
     etos.config.set("dataset", json.loads(args.dataset))
 
     with info(text="Checking connectivity to ETOS", spinner="dots") as spinner:

--- a/src/etos_client/client.py
+++ b/src/etos_client/client.py
@@ -83,14 +83,14 @@ class ETOSClient:
             "log_area_provider": self.etos.config.get("log_area_provider"),
             "test_suite_url": self.etos.config.get("test_suite"),
         }
-        identity = self.etos.config.get("identity")
-        if self.is_uuid(identity):
-            data["artifact_id"] = identity
-        elif self.is_packageurl(identity):
-            data["artifact_identity"] = identity
+        artifact_identifier = self.etos.config.get("artifact_identifier")
+        if self.is_uuid(artifact_identifier):
+            data["artifact_id"] = artifact_identifier
+        elif self.is_packageurl(artifact_identifier):
+            data["artifact_identity"] = artifact_identifier
         else:
             raise ValueError(
-                "Identity %r is not a valid PackageURL or UUID." % identity
+                "Identity %r is not a valid PackageURL or UUID." % artifact_identifier
             )
         return data
 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#73

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add the ability to start ETOS using artifact ID instead of PackageURL string for more explicit IUT selection.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I opted to keep the packageurl imeplementation instead of removing as it would be a huge breaking change.

### Benefits
<!-- What benefits will be realized by the change? -->
We can start tests on a more explicit IUT, instead of relying on the package URL being unique.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None that I can think of.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
