### PR TITLE
Add proper exit on activityCanceled event from ETOS

### DIFF
--- a/src/etos_client/lib/graphql.py
+++ b/src/etos_client/lib/graphql.py
@@ -17,6 +17,7 @@
 from .graphql_queries import (
     ARTIFACTS,
     ACTIVITY_TRIGGERED,
+    ACTIVITY_CANCELED,
     CONFIDENCE_LEVEL,
     TEST_SUITE_STARTED,
     TEST_SUITE_FINISHED,
@@ -82,6 +83,28 @@ def request_activity(etos, suite_id):
             except StopIteration:
                 return None
             return activity
+    return None
+
+
+def request_activity_canceled(etos, activity_id):
+    """Request an activity event from graphql.
+
+    :param etos: ETOS client query etos.
+    :type etos: :obj:`etos_lib.etos.ETOS`
+    :param suite_id: ID of execution recipe triggering this activity.
+    :type suite_id: str
+    :return: Response from graphql or None
+    :rtype: dict or None
+    """
+    for response in request(etos, ACTIVITY_CANCELED % activity_id):
+        if response:
+            try:
+                _, activity_canceled = next(
+                    etos.graphql.search_for_nodes(response, "activityCanceled")
+                )
+            except StopIteration:
+                return None
+            return activity_canceled
     return None
 
 

--- a/src/etos_client/lib/graphql.py
+++ b/src/etos_client/lib/graphql.py
@@ -30,7 +30,7 @@ from .graphql_queries import (
 def request(etos, query):
     """Request graphql in a generator.
 
-    :param etos: ETOS client query etos.
+    :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
     :param query: Query to send to graphql.
     :type query: str
@@ -44,7 +44,7 @@ def request(etos, query):
 def request_suite(etos, suite_id):
     """Request a tercc from graphql.
 
-    :param etos: ETOS client query etos.
+    :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
     :param suite_id: ID of execution recipe.
     :type suite_id: str
@@ -67,7 +67,7 @@ def request_suite(etos, suite_id):
 def request_activity(etos, suite_id):
     """Request an activity event from graphql.
 
-    :param etos: ETOS client query etos.
+    :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
     :param suite_id: ID of execution recipe triggering this activity.
     :type suite_id: str
@@ -89,10 +89,10 @@ def request_activity(etos, suite_id):
 def request_activity_canceled(etos, activity_id):
     """Request an activity event from graphql.
 
-    :param etos: ETOS client query etos.
+    :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
-    :param suite_id: ID of execution recipe triggering this activity.
-    :type suite_id: str
+    :param activity_id: ID of the activity beeing canceled.
+    :type activity_id: str
     :return: Response from graphql or None
     :rtype: dict or None
     """
@@ -111,7 +111,7 @@ def request_activity_canceled(etos, activity_id):
 def request_test_suite_started(etos, activity_id):
     """Request test suite started from graphql.
 
-    :param etos: ETOS client query etos.
+    :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
     :param activity_id: ID of activity in which the test suites started
     :type activity_id: str
@@ -131,7 +131,7 @@ def request_test_suite_started(etos, activity_id):
 def request_test_suite_finished(etos, test_suite_ids):
     """Request test suite finished from graphql.
 
-    :param etos: ETOS client query etos.
+    :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
     :param test_suite_ids: list of test suite started IDs of which finished to search for.
     :type test_suite_ids: list
@@ -160,7 +160,7 @@ def request_test_suite_finished(etos, test_suite_ids):
 def request_confidence_level(etos, test_suite_ids):
     """Request confidence levels from graphql.
 
-    :param etos: ETOS client query etos.
+    :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
     :param test_suite_ids: list of test suite started IDs of which confidences to search for.
     :type test_suite_ids: list
@@ -188,7 +188,7 @@ def request_confidence_level(etos, test_suite_ids):
 def request_announcements(etos, ids):
     """Request announcements from graphql.
 
-    :param etos: ETOS client query etos.
+    :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
     :param ids: list of IDs of which announcements to search for.
     :type ids: list
@@ -211,7 +211,7 @@ def request_announcements(etos, ids):
 def request_environment(etos, ids):
     """Request environments from graphql.
 
-    :param etos: ETOS client query etos.
+    :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
     :param ids: list of IDs of which environments to search for.
     :type ids: list
@@ -234,7 +234,7 @@ def request_environment(etos, ids):
 def request_artifacts(etos, context):
     """Request artifacts from graphql.
 
-    :param etos: ETOS client query etos.
+    :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
     :param context: ID of the activity used in CONTEXT.
     :type context: str

--- a/src/etos_client/lib/graphql_queries.py
+++ b/src/etos_client/lib/graphql_queries.py
@@ -44,6 +44,20 @@ ACTIVITY_TRIGGERED = """
 }
 """
 
+ACTIVITY_CANCELED = """
+{
+  activityCanceled(search: "{'links.target': '%s'}") {
+    edges {
+      node {
+        data {
+          reason
+        }
+      }
+    }
+  }
+}
+"""
+
 
 TEST_SUITE_STARTED = """
 {

--- a/src/etos_client/lib/graphql_queries.py
+++ b/src/etos_client/lib/graphql_queries.py
@@ -46,7 +46,7 @@ ACTIVITY_TRIGGERED = """
 
 ACTIVITY_CANCELED = """
 {
-  activityCanceled(search: "{'links.target': '%s'}") {
+  activityCanceled(search: "{'links.type': 'ACTIVITY_EXECUTION', 'links.target': '%s'}") {
     edges {
       node {
         data {

--- a/src/etos_client/lib/test_result_handler.py
+++ b/src/etos_client/lib/test_result_handler.py
@@ -19,6 +19,7 @@ import time
 import logging
 from .graphql import (
     request_activity,
+    request_activity_canceled,
     request_confidence_level,
     request_test_suite_finished,
     request_test_suite_started,
@@ -282,6 +283,9 @@ class ETOSTestResultHandler:
             self.latest_announcement(spinner)
             time.sleep(10)
             self.events = self.get_events(self.etos.config.get("suite_id"))
+            canceled = request_activity_canceled(self.etos, self.activity_id)
+            if canceled:
+                return False, canceled["data"]["reason"]
             if not self.has_started:
                 continue
             spinner.text = self.spinner_text


### PR DESCRIPTION
### Applicable Issues
Fixes: eiffel-community/etos#85

### Description of the Change
Etos Client not exits properly on activityCanceled event from ETOS, no longer hanging for 24 hours.

### Benefits
We fail faster.

### Possible Drawbacks
None that I can think of.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>> 
