### PR TITLE
ETOS client now supports multiple suites from ESR

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,8 +92,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"etos_client"
-copyright = u"2020, Axis Communications AB"
+project = "etos_client"
+copyright = "2020, Axis Communications AB"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -241,7 +241,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "user_guide.tex", u"etos_client Documentation", u"", "manual"),
+    ("index", "user_guide.tex", "etos_client Documentation", "", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/src/etos_client/lib/graphql.py
+++ b/src/etos_client/lib/graphql.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Axis Communications AB.
+# Copyright 2020-2022 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -18,6 +18,7 @@ from .graphql_queries import (
     ARTIFACTS,
     ACTIVITY_TRIGGERED,
     ACTIVITY_CANCELED,
+    MAIN_TEST_SUITES_STARTED,
     TEST_SUITE_STARTED,
     TEST_SUITE_FINISHED,
     TEST_SUITE,
@@ -127,32 +128,46 @@ def request_test_suite_started(etos, activity_id):
     return None  # StopIteration
 
 
-def request_test_suite_finished(etos, test_suite_ids):
+def request_main_test_suites_started(etos, activity_id):
+    """Request test suite started from graphql.
+
+    :param etos: Etos Library instance for communicating with ETOS.
+    :type etos: :obj:`etos_lib.etos.ETOS`
+    :param activity_id: ID of activity in which the test suites started
+    :type activity_id: str
+    :return: Iterator of test suite started graphql responses.
+    :rtype: iterator
+    """
+    for response in request(etos, MAIN_TEST_SUITES_STARTED % activity_id):
+        if response:
+            for _, test_suite_started in etos.graphql.search_for_nodes(
+                response, "testSuiteStarted"
+            ):
+                yield test_suite_started
+            return None  # StopIteration
+    return None  # StopIteration
+
+
+def request_test_suite_finished(etos, test_suite_id):
     """Request test suite finished from graphql.
 
     :param etos: Etos Library instance for communicating with ETOS.
     :type etos: :obj:`etos_lib.etos.ETOS`
-    :param test_suite_ids: list of test suite started IDs of which finished to search for.
-    :type test_suite_ids: list
-    :return: Iterator of test suite finished graphql responses.
-    :rtype: iterator
+    :param test_suite_id: Test suite started ID of which finished to search for.
+    :type test_suite_id: list
+    :return: Test suite finished graphql response.
+    :rtype: dict
     """
-    or_query = "{'$or': ["
-    or_query += ", ".join(
-        [
-            f"{{'links.type': 'TEST_SUITE_EXECUTION', 'links.target': '{test_suite_id}'}}"
-            for test_suite_id in test_suite_ids
-        ]
-    )
-    or_query += "]}"
-    for response in request(etos, TEST_SUITE_FINISHED % or_query):
+    for response in request(etos, TEST_SUITE_FINISHED % test_suite_id):
         if response:
-            for _, test_suite_finished in etos.graphql.search_for_nodes(
-                response, "testSuiteFinished"
-            ):
-                yield test_suite_finished
-            return None  # StopIteration
-    return None  # StopIteration
+            try:
+                _, test_suite_finished = next(
+                    etos.graphql.search_for_nodes(response, "testSuiteFinished")
+                )
+            except StopIteration:
+                return None
+            return test_suite_finished
+    return None
 
 
 def request_announcements(etos, ids):

--- a/src/etos_client/lib/graphql_queries.py
+++ b/src/etos_client/lib/graphql_queries.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Axis Communications AB.
+# Copyright 2020-2022 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -61,14 +61,24 @@ ACTIVITY_CANCELED = """
 
 TEST_SUITE_STARTED = """
 {
-  testSuiteStarted(search:"{'links.type': 'CONTEXT', 'links.target': '%s'}") {
+  testSuiteStarted(search:"{'links.type': 'CAUSE', 'links.target': '%s'}") {
     edges {
       node {
-        data {
-          testSuiteCategories {
-            type
-          }
+        meta {
+          id
         }
+      }
+    }
+  }
+}
+"""
+
+
+MAIN_TEST_SUITES_STARTED = """
+{
+  testSuiteStarted(search:"{'links.type': 'CONTEXT', 'links.target': '%s', 'data.categories': {'$ne': 'Sub suite'}}") {
+    edges {
+      node {
         meta {
           id
         }
@@ -81,7 +91,7 @@ TEST_SUITE_STARTED = """
 
 TEST_SUITE_FINISHED = """
 {
-  testSuiteFinished(search: "%s") {
+  testSuiteFinished(search: "{'links.type': 'TEST_SUITE_EXECUTION', 'links.target': '%s'}" last: 1) {
     edges {
       node {
         data {
@@ -91,15 +101,6 @@ TEST_SUITE_FINISHED = """
           }
           testSuiteOutcome {
             verdict
-          }
-        }
-        links {
-          ... on TestSuiteExecution {
-            testSuiteStarted {
-              meta {
-                id
-              }
-            }
           }
         }
       }

--- a/src/etos_client/lib/log_handler.py
+++ b/src/etos_client/lib/log_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Axis Communications AB.
+# Copyright 2020-2022 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos-suite-runner#25

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Made sure that we support multiple main suites from ESR.
Cleaned up the result handler a little bit so that we're more sure about which test suites we get.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I wanted to clean up everything, but decided against it as it would become a too big review.
Before this change we sent fewer big requests to the ER, whilst now we send more small requests. I think that this is better, due to the occasional delays from the ER when doing bigger requests.

### Benefits
<!-- What benefits will be realized by the change? -->
Allows the client to work with the newest version of ESR

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
